### PR TITLE
Fix getting missed rotuers. mfg was empty.

### DIFF
--- a/bin/control_rancid.in
+++ b/bin/control_rancid.in
@@ -471,9 +471,13 @@ if [ -f $DIR/routers.up.missed ] ; then
 fi
 while [ $round -le $pass ]
 do
-    for router in `cat $devlistfile | cut -d: -f1`
+    for router in `cat $devlistfile`
     do
-	mfg=$2
+	OFS=$IFS
+	IFS=':'
+	set $router
+	IFS=$OFS
+	router=$1; mfg=$2
 
 	if [ ! -s $router.new ]
 	then


### PR DESCRIPTION
Getting missed routers currently fails with:
unknown router manufacturer for <router_name>:

Missed routers code in control_rancid is broken. This patch reverts the behavior to that of upstream.
