### PR TITLE
git diff --quiet implies --exit-code

### DIFF
--- a/bin/control_rancid.in
+++ b/bin/control_rancid.in
@@ -819,21 +819,21 @@ case $RCSSYS in
 	    git commit -m "$message"
 	    if [ $? -eq 0 ]; then
 		# only generate a diff if the commit was successful
-            if [ $HTMLMAILS == YES ]; then 
-		git diff --patch-with-stat --quiet HEAD^ HEAD -- .
-		if [ $? -eq 0 ] ; then
-		    # only process HTML mail if there really is a difference
-                    git diff --color --patch-with-stat HEAD^ HEAD -- .  | ansi2html >$TMP.diff
-		fi
-            else
-                git diff --patch-with-stat HEAD^ HEAD -- . >$TMP.diff
-            fi
-	    if [ $RCSSYS = "git-remote" ] ; then
-		# only push to remotes if commit was successful
-		for repo in $(git remote) ; do
-		    git push ${repo}
-		done
-	    fi
+            	if [ $HTMLMAILS == YES ]; then 
+                    git diff --patch-with-stat --quiet HEAD^ HEAD -- .
+                    if [ $? -eq 1 ] ; then
+                        # only process HTML mail if there really is a difference
+                        git diff --color --patch-with-stat HEAD^ HEAD -- .  | ansi2html >$TMP.diff
+		    fi
+                else
+                    git diff --patch-with-stat HEAD^ HEAD -- . >$TMP.diff
+                fi
+	        if [ $RCSSYS = "git-remote" ] ; then
+                    # only push to remotes if commit was successful
+		    for repo in $(git remote) ; do
+		        git push ${repo}
+		    done
+	        fi
 	    fi
 	) 200>$BASEDIR/.lockfile
 	;;


### PR DESCRIPTION
With --quiet git-diff will return 1 if there is a diff.
Without this it will not send an e-mail.

I only changed the indentation, the only line getting a change is 824:
-if [ $? -eq 0 ] ; then
+if [ $? -eq 1 ] ; then 
