### PR TITLE
Remove / from ${LOGDIR} in rancid-cvs.in

### DIFF
--- a/bin/rancid-cvs.in
+++ b/bin/rancid-cvs.in
@@ -129,8 +129,8 @@ if [ ! -d $CVSROOT ]; then
 fi
 
 # Log dir
-if [ ! -d ${LOGDIR#${BASEDIR}} ]; then
-    mkdir ${LOGDIR#${BASEDIR}}
+if [ ! -d ${LOGDIR#${BASEDIR}/} ]; then
+    mkdir ${LOGDIR#${BASEDIR}/}
 fi
 
 # Which groups to do


### PR DESCRIPTION
Last PR today, I promise. Thank you all the quick merges.

I found that I need to remove the '/' from the $LOGDIR path, otherwise `rancid-cvs` tries to create `/logs` which fails.
