### PR TITLE
Added password removal capability to the following Cisco line:

### DIFF
--- a/bin/rancid.in
+++ b/bin/rancid.in
@@ -2038,9 +2038,9 @@ sub WriteTerm {
            ProcessHistory("","","","! ip nhrp authentication <removed>\n");
            next;
     }
-    if (/^\s*add http/ && $filter_pwds >= 1) {
-           ProcessHistory("","","","! add http://<removed>\n");
-           next;
+    if (/^\s*add (\S*:\/\/\S*:)\S*(@\S*)/ && $filter_pwds >= 1) {
+        ProcessHistory("","","","! add $1<removed>$2\n");
+        next;
     }
 	if (/^(\s*ppp .* hostname) .*/ && $filter_pwds >= 1) {
 	    ProcessHistory("","","","!$1 <removed>\n"); next;

--- a/bin/rancid.in
+++ b/bin/rancid.in
@@ -2037,7 +2037,11 @@ sub WriteTerm {
 	if (/^\s*ip nhrp authentication / && $filter_pwds >= 1) {
            ProcessHistory("","","","! ip nhrp authentication <removed>\n");
            next;
-        }
+    }
+    if (/^\s*add http/ && $filter_pwds >= 1) {
+           ProcessHistory("","","","! add http://<removed>\n");
+           next;
+    }
 	if (/^(\s*ppp .* hostname) .*/ && $filter_pwds >= 1) {
 	    ProcessHistory("","","","!$1 <removed>\n"); next;
 	}


### PR DESCRIPTION
* add http:// (for DDNS authentication)

If someone can figure out a better method than the one I'm using, so it
leaves the rest of the http://(username):<removed>@host/path?option=<h>
stuff that would be great! Otherwise, this works well.

Signed-off-by: Michael Englehorn <Michael@englehorn.com>