### PR TITLE
Fix some breaking typos

### DIFF
--- a/bin/fnrancid.in
+++ b/bin/fnrancid.in
@@ -223,7 +223,7 @@ sub GetConf {
 			last if (/$prompt/);
 
 			if ((/^\s*-----END RSA PRIVATE KEY-----"/) ||
-				((/^\s*-----END ENCRYTPED PRIVATE KEY-----"/)) {
+				(/^\s*-----END ENCRYPTED PRIVATE KEY-----"/)) {
 				ProcessHistory("","","","#$_");
 				last;
 			}

--- a/configure
+++ b/configure
@@ -2248,7 +2248,7 @@ PACKAGE=`sed -n 's/.*package.*"\(.*\)".*/\1/p' $srcdir/include/version.h.in|tr -
 COPYYEARS="1997-2011"
 
 
-am__api_version='1.14'
+am__api_version='1.13'
 
 ac_aux_dir=
 for ac_dir in "$srcdir" "$srcdir/.." "$srcdir/../.."; do

--- a/configure
+++ b/configure
@@ -2248,7 +2248,7 @@ PACKAGE=`sed -n 's/.*package.*"\(.*\)".*/\1/p' $srcdir/include/version.h.in|tr -
 COPYYEARS="1997-2011"
 
 
-am__api_version='1.13'
+am__api_version='1.14'
 
 ac_aux_dir=
 for ac_dir in "$srcdir" "$srcdir/.." "$srcdir/../.."; do


### PR DESCRIPTION
An errant bracket and misspelled 'ENCRYPTED' result in the majority of the config file being excluded.