### PR TITLE
Fix vyos

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -39,9 +39,9 @@
 ## CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 #  The expect login scripts were based on Erik Sherk's gwtn, by permission.
-# 
+#
 #  The original looking glass software was written by Ed Kern, provided by
 #  permission and modified beyond recognition.
 
@@ -56,7 +56,8 @@ bin_SCRIPTS = agmrancid alogin arancid arrancid avologin avorancid blogin \
 	mrvlogin mrvrancid mtlogin mtrancid nlogin nrancid nslogin nsrancid \
 	nxrancid rancid_par pflogin pfrancid prancid rancid rivlogin rivrancid rrancid srancid \
 	telcorancid tlogin tntlogin tntrancid trancid ubnt-es-rancid urancid ucsrancid \
-	xrancid xrrancid zrancid zyrancid dlogin drancid shelllogin shellrancid
+	xrancid xrrancid zrancid zyrancid dlogin drancid shelllogin shellrancid \
+	vlogin vrancid
 
 bin_SCRIPTS += lg.cgi lgform.cgi rancid-cvs rancid-fe rancid-run control_rancid
 EXTRA_DIST= lg.cgi.in lgform.cgi.in rancid-cvs.in rancid-fe.in rancid-run.in \

--- a/bin/Makefile.in
+++ b/bin/Makefile.in
@@ -14,9 +14,9 @@
 
 @SET_MAKE@
 
-# 
+#
 #  The expect login scripts were based on Erik Sherk's gwtn, by permission.
-# 
+#
 #  The original looking glass software was written by Ed Kern, provided by
 #  permission and modified beyond recognition.
 
@@ -112,6 +112,7 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
 	$(srcdir)/tntrancid.in $(srcdir)/telcorancid.in \
 	$(srcdir)/trancid.in $(srcdir)/ubnt-es-rancid.in \
 	$(srcdir)/ucsrancid.in $(srcdir)/urancid.in \
+	$(srcdir)/vlogin.in $(srcdir)/vrancid.in \
 	$(srcdir)/xrancid.in $(srcdir)/xrrancid.in \
 	$(srcdir)/zrancid.in $(srcdir)/zyrancid.in \
 	$(top_srcdir)/depcomp
@@ -131,7 +132,7 @@ CONFIG_CLEAN_FILES = agmrancid alogin arancid arrancid avologin \
 	nxrancid pflogin pfrancid prancid rancid_par rivlogin \
 	rivrancid rrancid shellrancid shelllogin srancid tlogin \
 	tntlogin tntrancid telcorancid trancid ubnt-es-rancid \
-	ucsrancid urancid xrancid xrrancid zrancid zyrancid
+	ucsrancid urancid vlogin vrancid xrancid xrrancid zrancid zyrancid
 CONFIG_CLEAN_VPATH_FILES =
 am__installdirs = "$(DESTDIR)$(bindir)" "$(DESTDIR)$(bindir)"
 PROGRAMS = $(bin_PROGRAMS)
@@ -173,11 +174,11 @@ am__v_P_1 = :
 AM_V_GEN = $(am__v_GEN_@AM_V@)
 am__v_GEN_ = $(am__v_GEN_@AM_DEFAULT_V@)
 am__v_GEN_0 = @echo "  GEN     " $@;
-am__v_GEN_1 = 
+am__v_GEN_1 =
 AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
-am__v_at_1 = 
+am__v_at_1 =
 DEFAULT_INCLUDES = -I.@am__isrc@ -I$(top_builddir)/include
 depcomp = $(SHELL) $(top_srcdir)/depcomp
 am__depfiles_maybe = depfiles
@@ -187,13 +188,13 @@ COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 AM_V_CC = $(am__v_CC_@AM_V@)
 am__v_CC_ = $(am__v_CC_@AM_DEFAULT_V@)
 am__v_CC_0 = @echo "  CC      " $@;
-am__v_CC_1 = 
+am__v_CC_1 =
 CCLD = $(CC)
 LINK = $(CCLD) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
 AM_V_CCLD = $(am__v_CCLD_@AM_V@)
 am__v_CCLD_ = $(am__v_CCLD_@AM_DEFAULT_V@)
 am__v_CCLD_0 = @echo "  CCLD    " $@;
-am__v_CCLD_1 = 
+am__v_CCLD_1 =
 SOURCES = $(hpuifilter_SOURCES)
 DIST_SOURCES = $(hpuifilter_SOURCES)
 am__can_run_installinfo = \
@@ -354,8 +355,8 @@ bin_SCRIPTS = agmrancid alogin arancid arrancid avologin avorancid \
 	nlogin nrancid nslogin nsrancid nxrancid rancid_par pflogin \
 	pfrancid prancid rancid rivlogin rivrancid rrancid srancid \
 	telcorancid tlogin tntlogin tntrancid trancid ubnt-es-rancid \
-	urancid ucsrancid xrancid xrrancid zrancid zyrancid dlogin \
-	drancid shelllogin shellrancid lg.cgi lgform.cgi rancid-cvs \
+	urancid ucsrancid vlogin vrancid xrancid xrrancid zrancid zyrancid \
+	dlogin drancid shelllogin shellrancid lg.cgi lgform.cgi rancid-cvs \
 	rancid-fe rancid-run control_rancid
 EXTRA_DIST = lg.cgi.in lgform.cgi.in rancid-cvs.in rancid-fe.in rancid-run.in \
 	control_rancid.in
@@ -546,6 +547,10 @@ ucsrancid: $(top_builddir)/config.status $(srcdir)/ucsrancid.in
 	cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@
 urancid: $(top_builddir)/config.status $(srcdir)/urancid.in
 	cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@
+vlogin: $(top_builddir)/config.status $(srcdir)/vlogin.in
+	cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@
+vrancid: $(top_builddir)/config.status $(srcdir)/vrancid.in
+	cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@
 xrancid: $(top_builddir)/config.status $(srcdir)/xrancid.in
 	cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@
 xrrancid: $(top_builddir)/config.status $(srcdir)/xrrancid.in
@@ -597,7 +602,7 @@ uninstall-binPROGRAMS:
 clean-binPROGRAMS:
 	-test -z "$(bin_PROGRAMS)" || rm -f $(bin_PROGRAMS)
 
-hpuifilter$(EXEEXT): $(hpuifilter_OBJECTS) $(hpuifilter_DEPENDENCIES) $(EXTRA_hpuifilter_DEPENDENCIES) 
+hpuifilter$(EXEEXT): $(hpuifilter_OBJECTS) $(hpuifilter_DEPENDENCIES) $(EXTRA_hpuifilter_DEPENDENCIES)
 	@rm -f hpuifilter$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(hpuifilter_OBJECTS) $(hpuifilter_LDADD) $(LIBS)
 install-binSCRIPTS: $(bin_SCRIPTS)

--- a/configure
+++ b/configure
@@ -6086,6 +6086,10 @@ ac_config_files="$ac_config_files bin/ucsrancid"
 
 ac_config_files="$ac_config_files bin/urancid"
 
+ac_config_files="$ac_config_files bin/vlogin"
+
+ac_config_files="$ac_config_files bin/vrancid"
+
 ac_config_files="$ac_config_files bin/xrancid"
 
 ac_config_files="$ac_config_files bin/xrrancid"
@@ -6897,6 +6901,8 @@ do
     "bin/ubnt-es-rancid") CONFIG_FILES="$CONFIG_FILES bin/ubnt-es-rancid" ;;
     "bin/ucsrancid") CONFIG_FILES="$CONFIG_FILES bin/ucsrancid" ;;
     "bin/urancid") CONFIG_FILES="$CONFIG_FILES bin/urancid" ;;
+    "bin/vrancid") CONFIG_FILES="$CONFIG_FILES bin/vrancid" ;;
+    "bin/vlogin") CONFIG_FILES="$CONFIG_FILES bin/vlogin" ;;
     "bin/xrancid") CONFIG_FILES="$CONFIG_FILES bin/xrancid" ;;
     "bin/xrrancid") CONFIG_FILES="$CONFIG_FILES bin/xrrancid" ;;
     "bin/zrancid") CONFIG_FILES="$CONFIG_FILES bin/zrancid" ;;
@@ -7648,6 +7654,8 @@ $as_echo X"$file" |
     "bin/ubnt-es-rancid":F) chmod a+x $ac_file ;;
     "bin/ucsrancid":F) chmod a+x $ac_file ;;
     "bin/urancid":F) chmod a+x $ac_file ;;
+    "bin/vlogin":F) chmod a+x $ac_file ;;
+    "bin/vrancid":F) chmod a+x $ac_file ;;
     "bin/xrancid":F) chmod a+x $ac_file ;;
     "bin/xrrancid":F) chmod a+x $ac_file ;;
     "bin/zrancid":F) chmod a+x $ac_file ;;

--- a/configure.ac
+++ b/configure.ac
@@ -321,7 +321,7 @@ else
 	# cygwin using windows ping?
 	$PING_PATH -n 1 127.0.0.1 > /dev/null 2>&1
 	if test $? -eq 0 ; then
-	    LG_PING_CMD="$PING_PATH -n 1" 
+	    LG_PING_CMD="$PING_PATH -n 1"
 	else
             AC_MSG_ERROR([can't figure out how to pass count == 1 to $PING_PATH.])
 	    exit 1
@@ -506,6 +506,7 @@ AC_CONFIG_FILES(bin/trancid, [chmod a+x $ac_file])
 AC_CONFIG_FILES(bin/ubnt-es-rancid, [chmod a+x $ac_file])
 AC_CONFIG_FILES(bin/ucsrancid, [chmod a+x $ac_file])
 AC_CONFIG_FILES(bin/urancid, [chmod a+x $ac_file])
+AC_CONFIG_FILES(bin/vlogin bin/vrancid, [chmod a+x $ac_file])
 AC_CONFIG_FILES(bin/xrancid, [chmod a+x $ac_file])
 AC_CONFIG_FILES(bin/xrrancid, [chmod a+x $ac_file])
 AC_CONFIG_FILES(bin/zrancid, [chmod a+x $ac_file])

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -39,9 +39,9 @@
 ## CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 #  The expect login scripts were based on Erik Sherk's gwtn, by permission.
-# 
+#
 #  The original looking glass software was written by Ed Kern, provided by
 #  permission and modified beyond recognition.
 
@@ -60,7 +60,7 @@ man_nogen_MANS = agmrancid.1 alogin.1 arancid.1 arrancid.1 avologin.1 \
 		par.1 pflogin.1 pfrancid.1 prancid.1 rancid-cvs.1 rancid-run.1 rancid.1 \
 		rancid_intro.1 rivlogin.1 rivrancid.1 router.db.5 rrancid.1 \
 		srancid.1 telcorancid.1 tlogin.1 tntlogin.1 tntrancid.1 trancid.1 ubnt-es-rancid.1 \
-		urancid.1 xrancid.1 xrrancid.1 zrancid.1 zyrancid.1
+		urancid.1 vlogin.1 vrancid.1 xrancid.1 xrrancid.1 zrancid.1 zyrancid.1
 
 man_MANS = $(man_nogen_MANS) $(man_gen_MANS)
 

--- a/man/Makefile.in
+++ b/man/Makefile.in
@@ -14,9 +14,9 @@
 
 @SET_MAKE@
 
-# 
+#
 #  The expect login scripts were based on Erik Sherk's gwtn, by permission.
-# 
+#
 #  The original looking glass software was written by Ed Kern, provided by
 #  permission and modified beyond recognition.
 VPATH = @srcdir@
@@ -100,11 +100,11 @@ am__v_P_1 = :
 AM_V_GEN = $(am__v_GEN_@AM_V@)
 am__v_GEN_ = $(am__v_GEN_@AM_DEFAULT_V@)
 am__v_GEN_0 = @echo "  GEN     " $@;
-am__v_GEN_1 = 
+am__v_GEN_1 =
 AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
-am__v_at_1 = 
+am__v_at_1 =
 depcomp =
 am__depfiles_maybe =
 SOURCES =
@@ -276,7 +276,7 @@ man_nogen_MANS = agmrancid.1 alogin.1 arancid.1 arrancid.1 avologin.1 \
 		par.1 pflogin.1 pfrancid.1 prancid.1 rancid-cvs.1 rancid-run.1 rancid.1 \
 		rancid_intro.1 rivlogin.1 rivrancid.1 router.db.5 rrancid.1 \
 		srancid.1 telcorancid.1 tlogin.1 tntlogin.1 tntrancid.1 trancid.1 ubnt-es-rancid.1 \
-		urancid.1 xrancid.1 xrrancid.1 zrancid.1 zyrancid.1
+		urancid.1 vlogin.1 vrancid.1 xrancid.1 xrrancid.1 zrancid.1 zyrancid.1
 
 man_MANS = $(man_nogen_MANS) $(man_gen_MANS)
 EXTRA_DIST = $(man_nogen_MANS) $(man_gen_MANS:%=%.in)

--- a/man/clogin.1
+++ b/man/clogin.1
@@ -9,40 +9,40 @@ clogin \- Cisco login script
 [\fB\-noenable\fP]
 [\fB\-dSV\fR]
 [\c
-.BI \-c\ 
+.BI \-c\
 command]
 [\c
-.BI \-E\ 
+.BI \-E\
 var=x]
 [\c
-.BI \-e\ 
+.BI \-e\
 enable-password]
 [\c
-.BI \-f\ 
+.BI \-f\
 cloginrc-file]
 [\c
-.BI \-p\ 
+.BI \-p\
 user-password]
 [\c
-.BI \-s\ 
+.BI \-s\
 script-file]
 [\c
-.BI \-t\ 
+.BI \-t\
 timeout]
 [\c
-.BI \-u\ 
+.BI \-u\
 username]
 [\c
-.BI \-v\ 
+.BI \-v\
 vty-password]
 [\c
-.BI \-w\ 
+.BI \-w\
 enable-username]
 [\c
-.BI \-x\ 
+.BI \-x\
 command-file]
 [\c
-.BI \-y\ 
+.BI \-y\
 ssh_cypher_type]
 router
 [router...]
@@ -68,7 +68,8 @@ Netscreen firewalls,
 Netscaler,
 Riverstone,
 Netopia,
-and Lucent TNT,
+Lucent TNT,
+and Vyatt/VyOS,
 named
 .B alogin,
 .B avologin,
@@ -85,6 +86,7 @@ named
 .B nslogin,
 .B rivlogin,
 .B tlogin,
+.B vlogin,
 and
 .B tntlogin,
 respectively.
@@ -255,7 +257,7 @@ to locate the
 configuration file.
 .El
 .SH FILES
-.ta \w'xHOME/xcloginrc  'u 
+.ta \w'xHOME/xcloginrc  'u
 \fI$HOME/.cloginrc\fR   Configuration file.
 .SH "SEE ALSO"
 .BR cloginrc (5),

--- a/man/rancid.1
+++ b/man/rancid.1
@@ -119,6 +119,9 @@ Ubiquiti EdgeSwitches
 .B urancid
 Ubiquiti (AirOS radios and ToughSwitches)
 .TP
+.B vrancid
+Vyatto/VyOS
+.TP
 .B xrancid
 Extreme switches
 .TP
@@ -174,8 +177,8 @@ looks for '>' to determine when a login is successful.  For example:
 .nf
 cat5k>
 cat5k> enable
-Password: 
-cat5k> (enable) 
+Password:
+cat5k> (enable)
 .fi
 .in -1i
 .PP

--- a/man/vlogin.1
+++ b/man/vlogin.1
@@ -1,0 +1,1 @@
+.so man1/clogin.1

--- a/man/vrancid.1
+++ b/man/vrancid.1
@@ -1,0 +1,1 @@
+.so man1/rancid.1


### PR DESCRIPTION
It looks like the VyOS binaries, `vlogin` and `vrancid`, were not being compiled during build because they were missing from the Makefiles. I added them and have tested the build and they are now properly included in the build.