### PR TITLE
From upstream rancid (version 3.2): improved ip address sorting.

### DIFF
--- a/bin/rancid.in
+++ b/bin/rancid.in
@@ -45,6 +45,7 @@
 # usage: rancid [-dV] [-l] [-f filename | hostname]
 #
 use Getopt::Std;
+use Socket qw(AF_INET AF_INET6 inet_pton);
 getopts('dflV');
 if ($opt_V) {
     print "@PACKAGE@ @VERSION@\n";
@@ -162,13 +163,40 @@ sub ipsort {
     @sorted_lines;
 }
 
-# These two routines will sort based upon IP addresses
+# ipaddrval(IPaddr) converts and IPv4/v6 address to a string for comparison.
+# Some may ask why not use Net::IP; performance.  We tried and it was horribly
+# slow.
 sub ipaddrval {
-    my(@a) = ($_[0] =~ m#^(\d+)\.(\d+)\.(\d+)\.(\d+)$#);
-    $a[3] + 256 * ($a[2] + 256 * ($a[1] +256 * $a[0]));
+    my($a) = @_;
+    my($norder);
+
+    if ($a =~ /:/) {
+        my($l);
+        if ($a =~ /\//) {
+            ($a, $l) = split(/\//, $a);
+        } else {
+            $l = 128;
+        }
+        $norder = inet_pton(AF_INET6, $a);
+        return unpack("H*", $norder) . unpack("H*", pack("C", $l));
+    } else {
+        my($l);
+        if ($a =~ /\//) {
+            ($a, $l) = split(/\//, $a);
+        } else {
+            $l = 32;
+        }
+        $norder = inet_pton(AF_INET, $a);
+        return(unpack("H*", $norder) . unpack("H*", pack("C", $l)));
+    }
+
+    # otherwise return the original key value, so as not to sort on null
+    return($_[0]);
 }
+
+# sortbyipaddr(IPaddr, IPaddr) compares two IPv4/v6 addresses like strcmp().
 sub sortbyipaddr {
-    &ipaddrval($a) <=> &ipaddrval($b);
+    &ipaddrval($a) cmp &ipaddrval($b);
 }
 
 # This routine parses "show version"


### PR DESCRIPTION
Without this patch, the items below do not sort correctly. The output
from IOS "show ip interface" and "show ipv6 interface" is unsorted
and doesn't come back in any deterministic order, so every invocation
of rancid leads to the "IPv4 Address:" and "IPv6 Address:" sections
being updated in git and emails sent to admins.

1) CIDR notation. For example,
   "!IPv4 Address: 172.30.2.2/28 on Vlan2502"
   On Cisco IOS, CIDR is output when the commands "show ip interface"
   and "show ipv6 interface" are executed.

2) IPv6 addresses. For example,
   "!IPv6 Address: FD80:EEEE:AC:1E18::1/64 on Vlan3024"
   On Cisco IOS, IPv6 CIDR is output when the command
   "show ipv6 interface" is executed.