### PR TITLE
CentOS 6 bugfix

### DIFF
--- a/bin/rancid.in
+++ b/bin/rancid.in
@@ -45,7 +45,8 @@
 # usage: rancid [-dV] [-l] [-f filename | hostname]
 #
 use Getopt::Std;
-use Socket qw(AF_INET AF_INET6 inet_pton);
+use Socket qw(AF_INET);
+use Socket6 qw(AF_INET6 inet_pton);
 getopts('dflV');
 if ($opt_V) {
     print "@PACKAGE@ @VERSION@\n";

--- a/update-spec.sh
+++ b/update-spec.sh
@@ -47,7 +47,7 @@ update_version_in_spec() {
 }
 
 update_release_in_spec() {
-    perl -pi -e 's/(^Release: )(\d)+/$1$ENV{RELEASE}/g' $spec_file
+    perl -pi -e 's/(^Release: )(\d(\.)?)+(\d)?/$1$ENV{RELEASE}/g' $spec_file
 }
 
 create_archive() {


### PR DESCRIPTION
The recently merged in changes from the 3.2 upstream broke CentOS 6 compatibility. This fixes it and should make further 3.2 changes not break CentOS 6.