### PR TITLE
Update notification language and fix ASA/PIX key scrubbing

### DIFF
--- a/bin/control_rancid.in
+++ b/bin/control_rancid.in
@@ -318,10 +318,10 @@ if [ $RALL -ne 0 -o $RDOWN -ne 0 -o $RUP -ne 0 ] ; then
 
     cd $DIR/configs
 
-    # Add new routers to the CVS structure.
+    # Add new devices to the CVS structure.
     for router in `comm -13 $DIR/routers.up $DIR/routers.up.new | cut -d: -f1`
     do
-	message="new router $router in group $GROUP"
+	message="new device $router in group $GROUP"
 	touch $router
 	case $RCSSYS in
 	    cvs )
@@ -538,9 +538,9 @@ do
 done
 
 if [ $alt_mailrcpt -eq 1 ] ; then
-    subject="router config diffs - courtesy of $mailrcpt $ALT_COMMIT"
+    subject="device config diffs - courtesy of $mailrcpt $ALT_COMMIT"
 else
-    subject="router config diffs $ALT_COMMIT"
+    subject="device config diffs $ALT_COMMIT"
 fi
 if [ "X$device" != "X" ] ; then
     message="updates of group $GROUP - courtesy of $mailrcpt $ALT_COMMIT"

--- a/bin/rancid.in
+++ b/bin/rancid.in
@@ -2115,7 +2115,7 @@ sub WriteTerm {
 	    next;
 	}
 	# ASA/PIX keys in more system:running-config
-	if (/^( pre-shared-key | key |failover key ).*/ && $filter_pwds >= 1) {
+	if (/^(( ikev1)? pre-shared-key | key |failover key ).*/ && $filter_pwds >= 1) {
 	    ProcessHistory("","","","!$1 <removed> $'"); next;
 	}
 	# ASA/PIX keys in more system:running-config

--- a/man/rancid_intro.1
+++ b/man/rancid_intro.1
@@ -47,7 +47,7 @@ a lost configuration.  See
 .BR rancid.conf (5)
 for more information on <group>s.
 .PP
-After filtering, a uni-diff (see 
+After filtering, a uni-diff (see
 .BR diff (1))
 of the result is produced
 for each of the devices in a group against that of the previous run of
@@ -69,11 +69,11 @@ for the device named dfw.shrubbery.net, which happens to be a Cisco GSR.
 .PP
 .ft CW
 .nf
-From: rancid 
+From: rancid
 To: rancid-shrubbery@shrubbery.net
-Subject: shrubbery router config diffs
+Subject: device config diffs
 Precedence: bulk
-  
+
 Index: configs/dfw.shrubbery.net
 ===================================================================
 retrieving revision 1.144
@@ -126,7 +126,7 @@ Run
 o
 Update the system's mail aliases file
 .IR /etc/aliases
-(see 
+(see
 .BR rancid.conf (5)).
 .\"
 .SH "SEE ALSO"

--- a/rancid-git.spec
+++ b/rancid-git.spec
@@ -33,8 +33,14 @@ Requires: shadow-utils
 Requires: findutils
 Requires: expect >= 5.40
 Requires: perl
+Requires: perl-CGI
+Requires: perl-LockFile-Simple
+Requires: perl-MailTools
 Requires: iputils
 Requires: logrotate
+Requires: git
+Requires: python-pip
+Requires: diffstat
 
 %description
 RANCID monitors a router's (or more generally a device's) configuration,

--- a/rancid-git.spec
+++ b/rancid-git.spec
@@ -1,9 +1,9 @@
-%global commit 89deb1cac7306c385c669a5a6b6744f6e08c054e
+%global commit cc801e15d45280624e192389e2e242c0bf961b87
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:    rancid-git
 Version: 2.3.9
-Release: 3%{?dist}
+Release: 4.1%{?dist}
 Summary: Really Awesome New Cisco confIg Differ (w/ git support)
 
 Group:   Applications/Internet
@@ -39,6 +39,7 @@ Requires: perl-MailTools
 Requires: iputils
 Requires: logrotate
 Requires: git
+Requires: perl-Socket6
 Requires: python-pip
 Requires: diffstat
 
@@ -128,6 +129,21 @@ fi
 
 
 %changelog
+* Wed Feb 03 2016 Sam Doran <github@samdoran.com> 2.3.9-4.1
+- Modify email subject and commit messages so they make more sense
+- Correct regexp for removing ASA/PIX keys
+
+* Tue Feb 02 2016 Sam Doran <github@samdoran.com> 2.3.9-4
+- Use inet_pton from Socket6 module to preserve CentOS 6 compatibility.
+  See https://bugzilla.redhat.com/show_bug.cgi?id=1224143 for details.
+
+* Wed Jan 20 2016 Frank Fegert <fra.nospam.nk@gmx.de> 2.3.9-4
+- Merged changes from upstream rancid (version 3.2).
+- Improved handling of Dell PowerConnect M-Series switch devices.
+
+* Mon Nov 16 2015 Ryan Chapman <rchapman@dataminr.com> 2.3.9-4
+- Improved ip address sorting (from upstream v3.2).
+
 * Fri Oct 30 2015 John Siegrist <john@complects.com> 2.3.9-3
 - Add make as missing BuildRequires dependency
 


### PR DESCRIPTION
User "device" instead of "router" in notification messages.
Incorporate fix from upstream v3.2 that properly scrubs ASA/PIX IPsec keys.