### PR TITLE
Properly remove community strings in new version of ASA

### DIFF
--- a/bin/rancid.in
+++ b/bin/rancid.in
@@ -2221,14 +2221,18 @@ sub WriteTerm {
 	    }
 	    next;
 	}
-	if (/^(snmp-server community) (\S+)/) {
-	    if ($filter_commstr) {
-		ProcessHistory("SNMPSERVERCOMM","keysort","$_",
-			       "!$1 <removed>$'") && next;
-	    } else {
-		ProcessHistory("SNMPSERVERCOMM","keysort","$_","$_") && next;
-	    }
-	}
+    # For ASA version 8.x and higher, the format changed a little. It is
+    # 'snmp-server host {interface {hostname | ip_address}} [trap | poll]
+    # [community  0 | 8 community-string] [version {1 | 2c | 3 username}]
+    # [udp-port port] '
+    if (/^(snmp-server .*community) ([08] )?(\S+)/) {
+        if ($filter_commstr) {
+        ProcessHistory("SNMPSERVERCOMM","keysort","$_",
+                   "!$1 <removed>$'") && next;
+        } else {
+        ProcessHistory("SNMPSERVERCOMM","keysort","$_","$_") && next;
+        }
+    }
 	# prune tacacs/radius server keys
 	if (/^((tacacs|radius)-server\s(\w*[-\s(\s\S+])*\s?key) (\d )?\S+/
 	    && $filter_pwds >= 1) {

--- a/rancid-git.spec
+++ b/rancid-git.spec
@@ -132,6 +132,7 @@ fi
 * Wed Feb 03 2016 Sam Doran <github@samdoran.com> 2.3.9-4.1
 - Modify email subject and commit messages so they make more sense
 - Correct regexp for removing ASA/PIX keys
+- Properly remove ASA community strings in ASA 8.x
 
 * Tue Feb 02 2016 Sam Doran <github@samdoran.com> 2.3.9-4
 - Use inet_pton from Socket6 module to preserve CentOS 6 compatibility.


### PR DESCRIPTION
This change is from the 3.2 upstream.